### PR TITLE
qtwebsockets 6.10.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr19/96255f9
+  - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr7/0d24cd8
+  - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr7/bdf4bf1
+  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr7/3f0cffd

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr19/96255f9
-  - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr7/0d24cd8
-  - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr7/bdf4bf1
-  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr7/3f0cffd

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,7 +3,7 @@ c_stdlib_version:  # [not linux]
   - 12.0           # [osx]
   - 2022.12        # [win]
 OSX_SDK_VER:       # [osx]
-  - 13.3           # [osx]
+  - 14.5           # [osx]
 
 # https://doc.qt.io/qt-6/windows.html
 c_compiler:    # [win]
@@ -14,11 +14,9 @@ cxx_compiler:  # [win]
 # XCode 15.0 came with SDK 14.0 and clang 15
 # https://en.wikipedia.org/wiki/Xcode
 c_compiler_version:    # [osx]
-  - 17                 # [osx]
+  - 20                 # [osx]
 cxx_compiler_version:  # [osx]
-  - 17                 # [osx]
+  - 20                 # [osx]
 
-# Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
-# 12.1 sysroot.
 CONDA_BUILD_SYSROOT:
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [osx and arm64]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX14.5.sdk  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtwebsockets" %}
-{% set version = "6.9.2" %}
+{% set version = "6.10.1" %}
 
 package:
   name: {{ name }}
@@ -7,11 +7,11 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: be833f667ed8d6c2f41c0b9d1f8addf20b8d2b11c3a9466ec6d70c62121708ee
+    sha256: 272ac7e94418e2b13b3384d73ba89dbd6b746d7661b44dce906f8bfc0795bd01
     folder: {{ name }}
 
 build:
-  number: 1
+  number: 0
   # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -41,7 +41,7 @@ test:
     - {{ stdlib('c') }}  # [linux]
     - {{ compiler('cxx') }}
     - cmake
-    - ninja
+    - ninja-base
     - qtbase-devel
   files:
     - run_qt_test.sh    # [unix]


### PR DESCRIPTION
qtwebsockets 6.10.1

**Destination channel:** defaults

### Links

- [PKG-11803](https://anaconda.atlassian.net/browse/PKG-11803) 

### Explanation of changes:

- Version update


[PKG-11803]: https://anaconda.atlassian.net/browse/PKG-11803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ