### PR TITLE
qtwebsockets 6.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr22/f9b7216
+  - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr9/e64e5f3
+  - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr9/fb94a22
+  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr9/8aadcd5

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,4 +5,4 @@ channels:
   - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr22/f9b7216
   - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr9/e64e5f3
   - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr9/fb94a22
-  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr9/8aadcd5
+  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr9/6d0b18c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr22/f9b7216
-  - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr9/e64e5f3
-  - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr9/fb94a22
-  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr9/6d0b18c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ test:
     - cmake
     - ninja-base
     - qtbase-devel
+    - zstd  # [osx]
   files:
     - run_qt_test.sh    # [unix]
     - run_qt_test.bat   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtwebsockets" %}
-{% set version = "6.10.2" %}
+{% set version = "6.11.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: eccc751bea509ef656d20029693987a0fc03c58e21c38f1351480f3c8eb42ebd
+    sha256: 569f10d1fb35195869576004f5b5ff09735d2f0319e2e8f0dd0f40c7ec31d032
     folder: {{ name }}
 
 build:
@@ -30,7 +30,7 @@ requirements:
     - msys2-flex     # [win]
     - msys2-gperf    # [win]
     - cmake
-    - ninja
+    - ninja-base
     - perl
   host:
     - qtbase-devel {{ version }}
@@ -60,7 +60,7 @@ test:
     - run_qt_test.bat   # [win]
 
 about:
-  home: https://www.qt.io/
+  home: https://www.qt.io
   license: LGPL-3.0-only
   license_file: {{ name }}/LICENSES/LGPL-3.0-only.txt
   license_family: LGPL
@@ -68,5 +68,5 @@ about:
   description: |
     Qt helps you create connected devices, UIs & applications that run
     anywhere on any device, on any operating system at any time ({{ name[2:] }} libraries).
-  doc_url: https://doc.qt.io/
+  doc_url: https://doc.qt.io
   dev_url: https://github.com/qt/{{ name }}


### PR DESCRIPTION
qtwebsockets 6.11

**Destination channel:** defaults

### Links

- [PKG-11821](https://anaconda.atlassian.net/browse/PKG-11821) 
- [Upstream repository](https://github.com/qt/qtwebsockets/tree/v6.11.0)

### Explanation of changes:

- version update


[PKG-11821]: https://anaconda.atlassian.net/browse/PKG-11821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ